### PR TITLE
Fix the buffer problem

### DIFF
--- a/bin/piPipes_RNASeq.sh
+++ b/bin/piPipes_RNASeq.sh
@@ -227,6 +227,7 @@ xrRNA_RIGHT_FQ=${READS_DIR}/${PREFIX}.x_rRNA.2.fq && \
 [ ! -f .${JOBUID}.status.${STEP}.genome_mapping ] && \
 STAR \
 	--runMode alignReads \
+	--limitOutSAMoneReadBytes 1000000 \
 	--genomeDir $STARINDEX \
 	--readFilesIn ${xrRNA_LEFT_FQ} ${xrRNA_RIGHT_FQ} \
 	--runThreadN $CPU \


### PR DESCRIPTION
Sometimes STAR will complain due to some crazy multimappers:

EXITING because of fatal error: buffer size for SAM output is too small
Solution: increase input parameter --limitOutSAMoneReadByte

I added --limitOutSAMoneReadBytes 1000000 according to this post at https://groups.google.com/forum/#!msg/rna-star/4FggDmGZh-U/j_YZ0JSrx28J
