### PR TITLE
Solve error derived from too many levels of symbolic links

### DIFF
--- a/bin/piPipes_install_genomes.sh
+++ b/bin/piPipes_install_genomes.sh
@@ -375,7 +375,7 @@ esac
 
 # unzipping the UCSC.RepeatMask.bed.gz shipped with the pipeline
 # if the piPipes already has this in the github, just unzip it
-[ ! -s UCSC.RepeatMask.bed -a -s UCSC.RepeatMask.bed.gz ] && gunzip UCSC.RepeatMask.bed.gz
+[ ! -s UCSC.RepeatMask.bed -a -s UCSC.RepeatMask.bed.gz ] && gunzip -f UCSC.RepeatMask.bed.gz
 # if the piPipes does not have it, download it from UCSC
 [ ! -s UCSC.RepeatMask.bed -a ! -s UCSC.RepeatMask.bed.gz ] && \
 	mkdir -p rmsk && \


### PR DESCRIPTION
When installing genome dm6, UCSC.RepeatMask.bed.gz is a symbolic link of dm6.UCSC.RepeatMask.bed.gz. `gunzip UCSC.RepeatMask.bed.gz` would report the error that 'too many levels of symbolic links'. Adding -f would override this error.